### PR TITLE
Passing existing graph causes undefined variable or method exception

### DIFF
--- a/lib/pacer-neo4j/graph.rb
+++ b/lib/pacer-neo4j/graph.rb
@@ -41,7 +41,7 @@ module Pacer
         PacerGraph.new(Pacer::YamlEncoder, open, shutdown)
       else
         # Don't register the new graph so that it won't be automatically closed.
-        PacerGraph.new Pacer::YamlEncoder, proc { graph.neo.new(path_or_graph) }
+        PacerGraph.new Pacer::YamlEncoder, proc { neo.new(path_or_graph) }
       end
     end
   end


### PR DESCRIPTION
When passing an existing neo4j graph into Pacer:

``` ruby
Neo4j.db.start
Pacer.neo4j(Neo4j.db.graph)
```

I get an undefined variable or method exception for _graph_.  It looks like the scope of the _graph_ variable is only within the if-check for when _path_or_graph_ is a String.  My change is to simply remove the reference to _graph_ and use _neo.new_ directly.
