### PR TITLE
Fix the createKeyIndex problem with neo4j after a batch insertion mode.

### DIFF
--- a/lib/pacer-neo4j/blueprints_graph.rb
+++ b/lib/pacer-neo4j/blueprints_graph.rb
@@ -10,6 +10,11 @@ module Pacer
         tgi[:tx_depth] || 0
       end
 
+      def createKeyIndex(name, clazz, *params)
+        super(name, clazz, *params)
+        commit()
+      end
+
       def autoStartTransaction
         if allow_auto_tx or tx_depth != 0
           super


### PR DESCRIPTION
Fix bug https://github.com/pangloss/pacer/issues/51, so now even after the usage of a BatchInserter or a GraphML Import, whenever we create a key index this is properly fix.

I've read, and test, some other strategies like passing some variables to the Neo4j constructor on runtime, but never success with anyone of that, so I think to flush the index content just in case of a neo4j graph is a proper solution to that. However I'm open to suggestions ;-)
